### PR TITLE
Move some logic from the controller to CronParsr

### DIFF
--- a/app/controllers/checker_controller.rb
+++ b/app/controllers/checker_controller.rb
@@ -3,12 +3,10 @@ class CheckerController < ApplicationController
   end
 
   def show
-    @cron = CronParser.new(params[:statement]).cron
-  rescue CronParser::InvalidStatement
-    flash[:error] = "Unrecognized cron statement '#{params[:statement]}'."
+    @cron_parser = CronParser.new(params[:statement])
+    @cron = @cron_parser.cron
+  rescue CronParser::Error
+    flash[:error] = @cron_parser.error_message
     redirect_to root_path(statement: params[:statement])
-  rescue CronParser::MissingStatement
-    flash[:error] = "You must provide a cron statement."
-    redirect_to root_path
   end
 end

--- a/app/models/cron_parser.rb
+++ b/app/models/cron_parser.rb
@@ -18,21 +18,30 @@ class CronParser
     Cron.new(cron_attributes)
   end
 
-private
+  def error_message
+    if statement.blank?
+      "You must provide a cron statement."
+    elsif !valid?
+      "Unrecognized cron statement '#{statement}'."
+    end
+  end
 
   def special_schedule?
     SPECIAL_SCHEDULES.include? statement_fragments.first
   end
+  private :special_schedule?
 
   def statement_fragments
     statement.split
   end
+  private :statement_fragments
 
   def command
     command_position = special_schedule? ? 1 : 5
 
     Array(statement_fragments[command_position..-1]).join(" ")
   end
+  private :command
 
   def cron_attributes
     if special_schedule?
@@ -51,7 +60,9 @@ private
       }
     end
   end
+  private :cron_attributes
 
-  InvalidStatement = Class.new(StandardError)
-  MissingStatement = Class.new(StandardError)
+  Error = Class.new(StandardError)
+  InvalidStatement = Class.new(Error)
+  MissingStatement = Class.new(Error)
 end

--- a/app/views/checker/show.html.haml
+++ b/app/views/checker/show.html.haml
@@ -1,3 +1,3 @@
 = render 'shared/form'
 
-= render 'cron', cron: @cron
+= render 'cron', cron: @cron_parser.cron

--- a/spec/models/cron_parser_spec.rb
+++ b/spec/models/cron_parser_spec.rb
@@ -52,7 +52,7 @@ describe CronParser do
     end
 
     it "raises an exception for an invalid statement" do
-      subject.statement = "asdf"
+      subject.statement = invalid_statement
       expect { subject.cron }.to raise_error(CronParser::InvalidStatement)
     end
 
@@ -61,6 +61,23 @@ describe CronParser do
       expect { subject.cron }.to raise_error(CronParser::MissingStatement)
       subject.statement = ""
       expect { subject.cron }.to raise_error(CronParser::MissingStatement)
+    end
+  end
+
+  context "#error_message" do
+    it "is nil for a valid cron statement" do
+      expect(CronParser.new(statement).error_message).to be_nil
+    end
+
+    it "has an appropriate message for an invalid cron statement" do
+      error_message = CronParser.new(invalid_statement).error_message
+      expect(error_message).to match(/unrecognized cron statement/i)
+      expect(error_message).to match(invalid_statement)
+    end
+
+    it "has an appropriate message for a missing cron statement" do
+      error_message = CronParser.new(nil).error_message
+      expect(error_message).to match(/you must provide a cron statement/i)
     end
   end
 end


### PR DESCRIPTION
Makes the controller simpler, with fewer edge cases. I'm not 100% happy with CronParser#error_message. I wonder if I'm missing another service object, like CronParseError. Also, I'd like to stop relying on CronParser#cron raising an exception when something's wrong.
